### PR TITLE
feat: don't rerequest reviews from approvers to not make them un-approve the PR

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -102,9 +102,13 @@ export async function handlePullRequest(
     try {
       const reviewers = utils.chooseReviewers(owner, config)
 
-      if (reviewers.length > 0) {
-        await pr.addReviewers(reviewers)
-        core.info(`Added reviewers to PR #${number}: ${reviewers.join(', ')}`)
+      // Re-requesting a review from someone that already approved makes them un-approve the PR, so we filter out the approvers
+      const approvers = await pr.getApprovers();
+      const reviewersToAdd = reviewers.filter((reviewer) => !approvers.includes(reviewer));
+
+      if (reviewersToAdd.length > 0) {
+        await pr.addReviewers(reviewersToAdd)
+        core.info(`Added reviewers to PR #${number}: ${reviewersToAdd.join(', ')}`)
       }
     } catch (error) {
       if (error instanceof Error) {

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -11,6 +11,21 @@ export class PullRequest {
     this.context = context
   }
 
+  async getApprovers(): Promise<string[]> {
+    const { owner, repo, number: pull_number } = this.context.issue;
+    try {
+      const result = await this.client.rest.pulls.listReviews({
+        owner,
+        repo,
+        pull_number,
+      });
+      return result.filter((review) => review.state === 'APPROVED').map((review) => review.user.login);
+    } catch (err) {
+      core.debug(err);
+      return [];
+    }
+  }
+
   async addReviewers(reviewers: string[]): Promise<void> {
     const { owner, repo, number: pull_number } = this.context.issue
     const result = await this.client.rest.pulls.requestReviewers({


### PR DESCRIPTION
slack context: https://withpersona.slack.com/archives/C06TU98F44D/p1720721570873969

i opted not to just remove synchronize from persona-web since we may still want it if someone initially just created a WIP PR, then wanted to add reviewers afterwards by adding the label (or just forgot to add upon create)

**Potential Risk**

Worst Case Incident: SEV4
auto-assign-action bot breaks

**Testing Strategy**
tested the filtering + mapping logic on the sample response in https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28#list-reviews-for-a-pull-request
<img width="363" alt="Screenshot 2024-07-17 at 4 41 48 PM" src="https://github.com/user-attachments/assets/e680553f-3507-4c5f-a8b5-7b635bd14557">

thinking a better test later would be once this is merged and a new release for arushs/auto-assign-action is out, i'll test with the PR that updates version to new release and check if the action is working as expected - but curious if you had any thoughts on a better testing method
